### PR TITLE
Remove :version and :package-version from defgroup

### DIFF
--- a/move-dup.el
+++ b/move-dup.el
@@ -195,9 +195,7 @@ DIRECTION is \"down\"."
 (defgroup move-dup nil
   "Eclipse-like moving and duplicating lines or rectangles."
   :group 'convenience
-  :group 'wp
-  :version "24.3"
-  :package-version "0.1.2")
+  :group 'wp)
 
 ;;;###autoload
 (define-minor-mode move-dup-mode


### PR DESCRIPTION
- :version is for specifying in which Emacs version the package was added
- :package-version doesn't match the value in the header: better to omit it
