### PR TITLE
Fix moving when no region is selected.

### DIFF
--- a/move-dup.el
+++ b/move-dup.el
@@ -102,7 +102,7 @@ If the prefix N is positive, this function moves the current line
 forward N lines; otherwise backward."
   (interactive "*p")
   (let ((col (current-column)))
-    (goto-char (save-excursion
+    (goto-char (save-mark-and-excursion
                  (push-mark)
                  (end-of-line)
                  (md/move-region n)


### PR DESCRIPTION
Region should remain off if it wasn't on when we started moving.