### PR TITLE
Add more default key bindings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 move-dup.el
 
-Copyright (C) 2014-2019 Jimmy Yuen Ho Wong
+Copyright (C) 2014-2020 Jimmy Yuen Ho Wong
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ above.
 (global-move-dup-mode)
 ```
 
+If you are using `package.el` you can rebind default key-bindings the following
+way.
+
+```elisp
+(use-package move-dup
+  :bind (
+         ("M-p" . md-move-lines-up)
+         ("C-M-p" . md-duplicate-up)
+         ("M-n" . md-move-lines-down)
+         ("C-M-n" . md-duplicate-down)
+         )
+  )
+```
+
+Beware that this way you have to map _all_ the key-bindings you need, not just
+the ones you'd like to remap.
+
 You can also turn on `move-dup-mode` individually for each buffer.
 
 ```elisp

--- a/move-dup.el
+++ b/move-dup.el
@@ -1,6 +1,6 @@
 ;;; move-dup.el --- Eclipse-like moving and duplicating lines or rectangles.
 
-;; Copyright (C) 2014-2019 Jimmy Yuen Ho Wong
+;; Copyright (C) 2014-2020 Jimmy Yuen Ho Wong
 
 ;; This program is free software: you can redistribute it and/or modify it under
 ;; the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
I figured,  adding `p` and `n` for navigation along with arrow keys won't hurt because

* `C-p` and `C-n` are default navigation keys in vanilla Emacs for going one line up or down,
* `M-p` and `M-n` are not binded to any action by default in Emacs,
* a similar package [`move-lines`][1] use these bindings (some users might have switched to `move-dup` from `move-lines` due to the former being available in MELPA as opposite to the latter one),
* `magit` users should be familiar with these bindings, too :)

[1]: https://github.com/targzeta/move-lines